### PR TITLE
Seclists fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
       run: docker exec -t $container which hydra
     
     - name: Check for Seclists presence
-      run: ls /usr/share/seclists
+      run: docker exec -t $container ls /usr/share/seclists
     
     - name: Check for rockyou presence
-      run: ls /usr/share/wordlists/rockyou.txt
+      run: docker exec -t $container ls /usr/share/wordlists/rockyou.txt
     
     - name: Clean up the running container
       run: docker stop $container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,11 @@ jobs:
     - name: Verify that hydra is available
       run: docker exec -t $container which hydra
     
+    - name: Check for Seclists presence
+      run: ls /usr/share/wordlists/seclists
+    
+    - name: Check for rockyou presence
+      run: ls /usr/share/wordlists/rockyou.txt
+    
     - name: Clean up the running container
       run: docker stop $container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: docker exec -t $container which hydra
     
     - name: Check for Seclists presence
-      run: ls /usr/share/wordlists/seclists
+      run: ls /usr/share/seclists
     
     - name: Check for rockyou presence
       run: ls /usr/share/wordlists/rockyou.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Deploy the Docker image to GitHub Package Registry
+    - name: Deploy the Docker image to GitHub Package Registry - Semver
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: artis3n/kali-artis3n/kali
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+        registry: docker.pkg.github.com
+        tag_semver: true
+
+    - name: Deploy the Docker image to GitHub Package Registry - Latest
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: artis3n/kali-artis3n/kali
@@ -31,13 +40,19 @@ jobs:
         password: ${{ github.token }}
         registry: docker.pkg.github.com
         tags: "latest"
-        tag_semver: true
 
-    - name: Deploy the Docker image to Docker Hub
+    - name: Deploy the Docker image to Docker Hub - Semver
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: artis3n/kali
+        username: ${{ secrets.docker_username }}
+        password: ${{ secrets.docker_password }}
+        tag_semver: true
+    
+    - name: Deploy the Docker image to Docker Hub - Latest
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: artis3n/kali
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_password }}
         tags: "latest"
-        tag_semver: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ LABEL maintainer="Artis3n"
 ENV TERM=xterm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends systemd seclists \
-    python3 python3-pip python3-wheel python3-setuptools \
+    && apt-get install -y --no-install-recommends systemd wordlists \
+    python3 python3-pip python3-wheel python3-setuptools sslyze \
     git curl less vim metasploit-framework nmap ssh-client \
     manpages file zip john hydra lsof exploitdb awscli sqlmap \
     # autorecon dependencies
@@ -24,6 +24,8 @@ RUN mkdir /tools \
     && git clone --depth 1 https://github.com/Tib3rius/AutoRecon.git /tools/AutoRecon \
     && cd /tools/AutoRecon && pip3 install -r requirements.txt \
     && ln -s /tools/AutoRecon/autorecon.py /usr/local/bin/autorecon
+
+RUN gzip -d /usr/share/wordlists/rockyou.txt.gz
 
 RUN service postgresql start && msfdb init
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,45 @@
 FROM kalilinux/kali-rolling:latest
-LABEL maintainer="Artis3n"
+LABEL maintainer="Artis3n <dev@artis3nal.com>"
+
 ENV TERM=xterm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends systemd wordlists \
-    python3 python3-pip python3-wheel python3-setuptools sslyze \
-    git curl less vim metasploit-framework nmap ssh-client \
-    manpages file zip john hydra lsof exploitdb awscli sqlmap \
+    && apt-get install -y --no-install-recommends amass awscli curl \
+    exploitdb file git hydra john less lsof man-db \
+    metasploit-framework nmap python3 python3-pip python3-setuptools \
+    python3-wheel ssh-client sslyze sqlmap systemd vim zip \
     # autorecon dependencies
-    samba gobuster nikto whatweb onesixtyone oscanner enum4linux smbclient \
-    proxychains4 smbmap smtp-user-enum snmpcheck sslscan tnscmd10g \
+    enum4linux gobuster nikto onesixtyone oscanner proxychains4 samba \
+    smbclient smbmap smtp-user-enum snmpcheck sslscan tnscmd10g whatweb \
     # Has to run after systemd is installed
     # Needed for msfdb init
     && apt-get install -y --no-install-recommends systemctl \
-    # Slim down container size
+    # Slim down layer size
     && apt-get autoremove -y \
     && apt-get autoclean -y \
     # Remove apt-get cache from the layer to reduce container size
     && rm -rf /var/lib/apt/lists/*
 
+RUN service postgresql start && msfdb init
+
+# Install and configure AutoRecon
 RUN mkdir /tools \
-    # Install and configure AutoRecon
     && git clone --depth 1 https://github.com/Tib3rius/AutoRecon.git /tools/AutoRecon \
-    && cd /tools/AutoRecon && pip3 install -r requirements.txt \
+    && cd /tools/AutoRecon \
+    && pip3 install -r requirements.txt \
     && ln -s /tools/AutoRecon/autorecon.py /usr/local/bin/autorecon
 
-RUN gzip -d /usr/share/wordlists/rockyou.txt.gz
+# Install Seclists
+RUN mkdir -p /usr/share/seclists \
+    # This clone takes a million years.
+    # The apt-get install seclists command doesn't work from the Dockerfile, however.
+    && git clone --depth 1 https://github.com/danielmiessler/SecLists.git /usr/share/seclists
 
-RUN service postgresql start && msfdb init
+# Prepare rockyou wordlist
+RUN mkdir -p /usr/share/wordlists \
+    && cp /usr/share/seclists/Passwords/Leaked-Databases/rockyou.txt.tar.gz /usr/share/wordlists/ \
+    && cd /usr/share/wordlists \
+    && tar -xzf rockyou.txt.tar.gz
 
 # Need to start postgresql any time the container comes up
 # systemctl enable postgresql doesn't seem to take effect

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ install:
 
 .PHONY: size
 size:
-	dive build --no-cache test/kali .
+	dive build --no-cache -t test/kali .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+#!/usr/bin/make
+
+.PHONY: install
+install:
+	if [ ! -f /usr/local/bin/dive ]; then wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb && sudo apt install ./dive_0.9.2_linux_amd64.deb && rm dive*.deb; else echo "Dive installed, taking no action"; fi;
+
+.PHONY: size
+size:
+	dive build --no-cache test/kali .

--- a/README.md
+++ b/README.md
@@ -11,15 +11,24 @@ A kalilinux/kali-rolling container with extra juice.
 [![GitHub followers](https://img.shields.io/github/followers/artis3n?style=social)](https://github.com/artis3n/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/artis3n?style=social)](https://twitter.com/Artis3n)
 
-The [kalilinux/kali-rolling](https://www.kali.org/docs/containers/official-kalilinux-docker-images/) container comes with few pre-installed services. It is meant to be lightweight and clocks in around 118 MB. This container is around 1.9 GB. It installs and pre-configures a number of frequently uses Kali tools. It is meant to allow you to get up and running with a Kali environment on an ephemeral host. Don't spend time configuring and tweaking - pull, run, execute, pwn.
+The [kalilinux/kali-rolling](https://www.kali.org/docs/containers/official-kalilinux-docker-images/) container comes with no pre-installed services.
+It is meant to be lightweight and clocks in around 118 MB.
+This container, uncompressed, is around 1.9 GB.
+It installs and pre-configures a number of frequently uses Kali tools.
+It is meant to allow you to quickly get up and running with a Kali environment on an ephemeral host.
+Don't spend time configuring and tweaking - pull, run, execute, pwn.
 
-A premium is placed on keeping this image as small as is reasonable given its intended purpose. For example, `searchploit` is installed in this image but `searchsploit -u` is not run to install exploitdb-papers because this increases the image size to 7.9 GB - a 6GB increase. Efficiency of the build image is checked with [dive](https://github.com/wagoodman/dive):
+A premium is placed on keeping this image as small as is reasonable given its intended purpose.
+For example, `searchploit` is installed in this image but `searchsploit -u` is not run to install exploitdb-papers because this increases the image size to 7.9 GB - a 6GB increase.
+Efficiency of the build image is checked with [dive](https://github.com/wagoodman/dive):
 
 ![Dive image efficiency](resources/dive-efficiency.png)
 
 <small>Last checked: 2020-03-09</small>
 
-The container is not meant for a persistent attacker environment. The intention is for a quick environment to run attacks and document the results outside of the container. The container does not mount a volume for persistent storage - although, like any container, storage inside the container will remain until you `docker rm`.
+The container is not meant for a persistent attacker environment.
+The intention is for a quick environment to run attacks and document the results outside of the container.
+The container does not mount a volume for persistent storage - although, like any container, storage inside the container will remain until you `docker rm`.
 
 ## Usage
 
@@ -93,11 +102,16 @@ docker stop kali && docker rm kali
 - Proxychains4 ([proxychains-ng](https://github.com/rofl0r/proxychains-ng))
 - Searchsploit ([ExploitDB](https://www.exploit-db.com/searchsploit))
 - JohnTheRipper (jumbo)
+- Seclists wordlist (/usr/share/seclists)
+- Rockyou wordlist (/usr/share/wordlists)
 - SQLMap
 - Hydra
+- SSLyze
 
 ## Contributions
 
-Missing a tool you would like pre-configured? File a ticket and I will add it. A pull request is also welcome.
+Missing a tool you would like pre-configured? File a ticket and I will add it.
+A pull request is also welcome.
 
-For any new tools, you must add validation tests to `.github/workflows/ci.yml`. Use the existing tests as a baseline. These tests ensure the tools are installed and pre-configured correctly.
+For any new tools, you must add validation tests to `.github/workflows/ci.yml`. Use the existing tests as a baseline.
+These tests ensure the tools are installed and pre-configured correctly.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ A kalilinux/kali-rolling container with extra juice.
 
 The [kalilinux/kali-rolling](https://www.kali.org/docs/containers/official-kalilinux-docker-images/) container comes with no pre-installed services.
 It is meant to be lightweight and clocks in around 118 MB.
-This container, uncompressed, is around 2.0 GB.
+This container, uncompressed, is around 3.5 GB.
 It installs and pre-configures a number of frequently uses Kali tools.
 It is meant to allow you to quickly get up and running with a Kali environment on an ephemeral host.
 Don't spend time configuring and tweaking - pull, run, execute, pwn.
 
 A premium is placed on keeping this image as small as is reasonable given its intended purpose.
-For example, `searchploit` is installed in this image but `searchsploit -u` is not run to install exploitdb-papers because this increases the image size to 7.9 GB - a 6GB increase.
-However, `seclists` is installed even though it is a large dataset because those wordlist files are commonly used.
+For example, `searchploit` is installed in this image but `searchsploit -u` is not run to install exploitdb-papers because this increases the image size by 6GB increase.
+However, `seclists` is installed even though it increases the build image by 1.6 GB because those wordlist files are commonly used.
 Efficiency of the build image is checked with [dive](https://github.com/wagoodman/dive):
 
 ![Dive image efficiency](resources/dive-efficiency.png)

--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ A kalilinux/kali-rolling container with extra juice.
 
 The [kalilinux/kali-rolling](https://www.kali.org/docs/containers/official-kalilinux-docker-images/) container comes with no pre-installed services.
 It is meant to be lightweight and clocks in around 118 MB.
-This container, uncompressed, is around 1.9 GB.
+This container, uncompressed, is around 2.0 GB.
 It installs and pre-configures a number of frequently uses Kali tools.
 It is meant to allow you to quickly get up and running with a Kali environment on an ephemeral host.
 Don't spend time configuring and tweaking - pull, run, execute, pwn.
 
 A premium is placed on keeping this image as small as is reasonable given its intended purpose.
 For example, `searchploit` is installed in this image but `searchsploit -u` is not run to install exploitdb-papers because this increases the image size to 7.9 GB - a 6GB increase.
+However, `seclists` is installed even though it is a large dataset because those wordlist files are commonly used.
 Efficiency of the build image is checked with [dive](https://github.com/wagoodman/dive):
 
 ![Dive image efficiency](resources/dive-efficiency.png)
 
-<small>Last checked: 2020-03-09</small>
+<small>Last checked: 2020-03-15</small>
 
 The container is not meant for a persistent attacker environment.
 The intention is for a quick environment to run attacks and document the results outside of the container.
@@ -79,8 +80,7 @@ docker stop kali && docker rm kali
 
 ## Configured tools
 
-- Metasploit / Meterpreter
-  - PostgreSQL 12
+- Amass
 - [AutoRecon](https://github.com/Tib3rius/AutoRecon)
   - curl
   - enum4linux
@@ -99,14 +99,16 @@ docker stop kali && docker rm kali
   - tnscmd10g
   - whatweb
   - wkhtmltoimage
-- Proxychains4 ([proxychains-ng](https://github.com/rofl0r/proxychains-ng))
-- Searchsploit ([ExploitDB](https://www.exploit-db.com/searchsploit))
-- JohnTheRipper (jumbo)
-- Seclists wordlist (/usr/share/seclists)
-- Rockyou wordlist (/usr/share/wordlists)
-- SQLMap
 - Hydra
+- JohnTheRipper (jumbo)
+- Metasploit / Meterpreter
+  - PostgreSQL 12
+- Proxychains4 ([proxychains-ng](https://github.com/rofl0r/proxychains-ng))
+- Rockyou wordlist (/usr/share/wordlists/rockyou.txt)
+- Searchsploit ([ExploitDB](https://www.exploit-db.com/searchsploit))
+- Seclists wordlist (/usr/share/seclists)
 - SSLyze
+- SQLMap
 
 ## Contributions
 

--- a/resources/dive-efficiency.png
+++ b/resources/dive-efficiency.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b8e9b755c654307dcc77afc8fc00b23717eb81a65e6b3910e986c4d08201320
-size 9298
+oid sha256:5bdd123e37905c6c1b94378a6fcde3812fbc8ce5f7bc1ee8dc022e7ffb43ca04
+size 9435

--- a/resources/dive-efficiency.png
+++ b/resources/dive-efficiency.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bdd123e37905c6c1b94378a6fcde3812fbc8ce5f7bc1ee8dc022e7ffb43ca04
-size 9435
+oid sha256:8df1664159e8232d88f3a4b8f96c8bcd0633caa23136f90582a15d8f93a25a04
+size 9245


### PR DESCRIPTION
Fixed installation of seclists and rockyou. `apt-get install seclists` didn't install it in the Dockerfile? Not sure why. Takes forever to `git clone` but that's just the build step, whatever.