### PR TITLE
Systemd failing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.github
+resources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Verify that hydra is available
       run: docker exec -t $container which hydra
     
-    - name: Verify that socat is available
-      run: docker exec -t $container which socat
+    - name: Verify that netcat is available
+      run: docker exec -t $container which nc
     
     - name: Verify that dotdotpwn is available
       run: docker exec -t $container which dotdotpwn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Docker Image CI
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 env:
   container: kali-${{github.sha}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
     - name: Verify that Proxychains-ng is available in the container
       run: docker exec -t $container which proxychains4
     
-    - name: Verify that MSFDB is initialized
-      run: docker exec -t $container msfdb status
-    
     - name: Verify that msfconsole is available in the container
       run: docker exec -t $container msfconsole -v
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build the Docker BASE image in the background
+    - name: Build the Docker BASE image
       run: docker build --target base -t $container:base .
 
     - name: Run the Docker image, making sure it stays up for these tests
       run: docker run --name $container -id --rm $container:base
 
-    - name: Verify AutoRecon is available in the container
+    - name: Verify that AutoRecon is available in the container
       run: docker exec -t $container autorecon -h
 
     - name: Verify that Proxychains-ng is available in the container
@@ -61,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build the Docker WORDLISTS image in the background
+    - name: Build the Docker WORDLISTS image
       run: docker build --target wordlists -t $container:wordlists .
     
     - name: Run the Docker image, making sure it stays up for these tests

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: master
+        ref: main
 
     - name: Deploy the Docker image to GitHub Package Registry (Wordlists)
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir /tools \
     && git clone --depth 1 https://github.com/Tib3rius/AutoRecon.git /tools/AutoRecon \
     && cd /tools/AutoRecon \
     && pip3 install -r requirements.txt \
-    && ln -s /tools/AutoRecon/autorecon.py /usr/local/bin/autorecon
+    && ln -s /tools/AutoRecon/src/autorecon/autorecon.py /usr/local/bin/autorecon
 
 ENV TERM=xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends amass awscli curl \
     dotdotpwn file git hydra impacket-scripts john less locate lsof \
     man-db netcat nmap python3 python3-pip python3-setuptools \
-    python3-wheel socat ssh-client sslyze sqlmap systemctl vim zip \
+    python3-wheel socat ssh-client sslyze sqlmap vim zip \
     # autorecon dependencies
     enum4linux gobuster nikto onesixtyone oscanner proxychains4 samba \
     smbclient smbmap smtp-user-enum snmpcheck sslscan tnscmd10g whatweb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends amass awscli curl \
     dotdotpwn exploitdb file git hydra impacket-scripts john less lsof \
-    man-db metasploit-framework nmap python3 python3-pip python3-setuptools \
+    man-db metasploit-framework netcat nmap python3 python3-pip python3-setuptools \
     python3-wheel socat ssh-client sslyze sqlmap systemd vim zip \
     # autorecon dependencies
     enum4linux gobuster nikto onesixtyone oscanner proxychains4 samba \

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,15 @@ install:
 
 .PHONY: size-base
 size-base:
-	dive build --no-cache --target base -t test/kali .
+	dive build --target base -t test/kali:base .
 
 .PHONY: size-wordlists
 size-wordlists:
-	dive build --no-cache --target wordlists -t test/kali .
+	dive build --target wordlists -t test/kali:wordlists .
 
 .PHONY: size
 size:
-	dive build --no-cache -t test/kali .
+	dive build -t test/kali:full .
 
 .PHONY: build
 build: build-all
@@ -26,10 +26,10 @@ build: build-all
 .PHONY: build-all
 build-all: build-base build-full
 
-.PHONY: build-base
-build-base:
+.PHONY: base
+base:
 	docker build --target base -t test/kali:base .
 
-.PHONY: build-full
-build-full:
+.PHONY: full
+full:
 	docker build --target wordlists -t test/kali:full .

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,22 @@ size-wordlists:
 
 .PHONY: size
 size:
-	dive build -t test/kali:full .
+	dive build -t test/kali:latest .
 
 .PHONY: build
 build: build-all
 
 .PHONY: build-all
-build-all: build-base build-full
+build-all: base wordlists latest
 
 .PHONY: base
 base:
 	docker build --target base -t test/kali:base .
 
-.PHONY: full
+.PHONY: wordlists
 full:
-	docker build --target wordlists -t test/kali:full .
+	docker build --target wordlists -t test/kali:wordlists .
+
+.PHONY: latest
+latest:
+	docker build --target wordlists -t test/kali .

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [kalilinux/kali-rolling](https://www.kali.org/docs/containers/official-kalil
 It is meant to be lightweight and clocks in around 118 MB.
 You must configure every service and tool you need from that base image.
 
-This container, uncompressed, is around 3.5 GB (or 2.0 GB without wordlists).
+This container, uncompressed, is around 4.1 GB (or 2.2 GB without wordlists).
 It installs and pre-configures a number of frequently uses Kali tools.
 It is meant to allow you to quickly get up and running with a Kali environment on an ephemeral host.
 Don't spend time configuring and tweaking - pull, run, execute, pwn.
@@ -44,11 +44,11 @@ Efficiency of the build image is checked with [dive](https://github.com/wagoodma
 | With wordlists | ![Dive image with wordlists efficiency](resources/dive-efficiency-wordlists.png) |
 | Without wordlists | ![Dive image without wordlists efficiency](resources/dive-efficiency-base.png) |
 
-<small>Last checked: 2020-03-15</small>
+<small>Last checked: 2020-06-12</small>
 
 The container is not meant for a persistent attacker environment.
 The intention is for a quick environment to run attacks and document the results outside of the container.
-The container does not mount a volume for persistent storage - although, like any container, storage inside the container will remain until you `docker rm`.
+The container does not expect a mounted volume for persistent storage - although, like any container, storage inside the container will remain until you `docker rm` and you may set up volumes as you prefer.
 
 ## Usage
 
@@ -74,11 +74,18 @@ docker run --name kali -id artis3n/kali:latest
 docker exec -t kali nmap -p- 127.0.0.1
 ```
 
+**Suggested**: Alias a command to the container, run commands through the container from your terminal with ease:
+
+```bash
+alias kali="docker exec -it kali"
+kali sqlmap -u ...
+```
+
 ![Docker Exec](/resources/docker-exec.png)
 
 ![Docker Exec AutoRecon](/resources/docker-exec-autorecon.png)
 
-Get a terminal for the backgrounded container:
+Get a terminal if you backgrounded the container:
 
 ```bash
 docker exec -it kali /bin/bash
@@ -97,13 +104,6 @@ Kill the backgrounded container:
 
 ```bash
 docker stop kali && docker rm kali
-```
-
-Alias a command to your container, run commands through the container from your terminal:
-
-```bash
-alias kali="docker exec -it kali"
-kali sqlmap -u ...
 ```
 
 ## Configured tools
@@ -136,10 +136,10 @@ kali sqlmap -u ...
 - Netcat
 - Proxychains4 ([proxychains-ng](https://github.com/rofl0r/proxychains-ng))
 - Rockyou wordlist (/usr/share/wordlists/rockyou.txt)
-  - Wordlists / Latest image only
+  - `wordlists` / `latest` image only
 - Searchsploit ([ExploitDB](https://www.exploit-db.com/searchsploit))
 - Seclists wordlist (/usr/share/seclists)
-  - Wordlists / Latest image only
+  - `wordlists` / `latest` image only
 - SSLyze
 - SQLMap
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ kali sqlmap -u ...
 - Searchsploit ([ExploitDB](https://www.exploit-db.com/searchsploit))
 - Seclists wordlist (/usr/share/seclists)
   - Wordlists / Latest image only
-- Socat
 - SSLyze
 - SQLMap
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ kali sqlmap -u ...
 - JohnTheRipper (jumbo)
 - Metasploit / Meterpreter
   - PostgreSQL 12
+- Netcat
 - Proxychains4 ([proxychains-ng](https://github.com/rofl0r/proxychains-ng))
 - Rockyou wordlist (/usr/share/wordlists/rockyou.txt)
   - Wordlists / Latest image only

--- a/resources/dive-efficiency-base.png
+++ b/resources/dive-efficiency-base.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e11a1730b1626569051b628eb9aff44e435e3915b10068a6f2cec84b6030a1e
-size 9404
+oid sha256:86476b98440c874f0eea2e56457f40c5681c3be0d335a7bd4b16c776c1d89b84
+size 6374

--- a/resources/dive-efficiency-wordlists.png
+++ b/resources/dive-efficiency-wordlists.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:611823f3d77038f3267b39707777f896576cf4f430d5187eb6f747fdb8021d17
-size 9005
+oid sha256:d663fe38a0cbf262aa7dacc53ba092647048e7cd5888f094f7dec9d51a14852b
+size 6406


### PR DESCRIPTION
Fixes #35 

Removed the `msfdb init` configuration as Metasploit can run without being connected to postgres. And, the database disappears once the container is killed so there's really no point to including it since it brings a whole bunch of `systemd` issues. An alternative is to set up a `docker-compose` format with a postgres container, however that adds complexity with manually `init`ing the metasploit database+user+configuration, which I'd like to avoid.